### PR TITLE
Add Roxygen: line to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Depends: R (>= 3.3.0)
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.0
 Imports:
   cli,
   clisymbols,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,3 +37,4 @@ Suggests:
   testthat
 URL: https://github.com/ropenscilabs/available
 BugReports: https://github.com/ropenscilabs/available/issues
+Roxygen: list(markdown = TRUE)

--- a/man/available.Rd
+++ b/man/available.Rd
@@ -14,14 +14,16 @@ default = TRUE. Default can be changed by setting
 \code{available.browse} in \code{.Rprofile}. See \link[base]{Startup}
 for more details.}
 
-\item{...}{Additional arguments passed to [utils::available.packages()].}
+\item{...}{Additional arguments passed to \code{\link[utils:available.packages]{utils::available.packages()}}.}
 }
 \description{
 Searches performed
-- Valid package name
-- Already taken on CRAN
-- Positive or negative sentiment
-- Urban Dictionary
+\itemize{
+\item Valid package name
+\item Already taken on CRAN
+\item Positive or negative sentiment
+\item Urban Dictionary
+}
 }
 \examples{
 \dontrun{

--- a/man/available_on_cran.Rd
+++ b/man/available_on_cran.Rd
@@ -16,7 +16,7 @@ available_on_cran(name, repos = default_cran_repos, ...)
     character vector, the base URL(s) of the repositories to use.
   }
 
-\item{...}{Additional arguments passed to [utils::available.packages()].}
+\item{...}{Additional arguments passed to \code{\link[utils:available.packages]{utils::available.packages()}}.}
 }
 \description{
 See if a name is available on CRAN

--- a/man/create.Rd
+++ b/man/create.Rd
@@ -9,7 +9,7 @@ create(name, ...)
 \arguments{
 \item{name}{Name of package to search}
 
-\item{...}{Additional arguments passed to [usethis::create_package()].}
+\item{...}{Additional arguments passed to \code{\link[usethis:create_package]{usethis::create_package()}}.}
 }
 \description{
 Check a new package name and possibly create it

--- a/man/suggest.Rd
+++ b/man/suggest.Rd
@@ -15,7 +15,7 @@ suggest(path = ".", field = c("Title", "Description"), text = NULL)
 }
 \description{
 If the package you are using already has a title, simply pass the path to
-the package root in `path`. Otherwise use `title` to specify a potential
+the package root in \code{path}. Otherwise use \code{title} to specify a potential
 title.
 }
 \examples{


### PR DESCRIPTION
I noticed some of the links to **utils** functions were broken. I added the line to DESCRIPTION and rebuilt the helpfiles.

Additional query: is there a typo in the name of `get_wikipidia()`, should it be `get_wikipedia()` to match the spelling of the website?